### PR TITLE
Change package names to match Buster names

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,6 +52,6 @@ mysql_users: []
 
 # List of apt packages to install
 mysql_packages:
-  - mysql-server
-  - mysql-client
+  - default-mysql-server
+  - default-mysql-client
   - python-mysqldb


### PR DESCRIPTION
The old packages were transitional in Stretch already. In Buster, they
have been removed. However, this should probably use a conditional in
order to not affect other distributions. The packages with the "default"
prefix exist in Stretch but not in Jessie in case the latter is needed.